### PR TITLE
Fix redis call to allow for multiple keywords

### DIFF
--- a/lib/reds.js
+++ b/lib/reds.js
@@ -241,7 +241,7 @@ Query.prototype.end = function(fn){
   if (!keys.length) return fn(null, []);
   var tkey = key + 'tmpkey';
   db.multi([
-    [type, tkey, keys.length, keys],
+    [type, tkey, keys.length].concat(keys),
     ['zrevrange', tkey, 0, -1],
     ['zremrangebyrank', tkey, 0, -1],
   ]).exec(function(err, ids) {


### PR DESCRIPTION
When searching with more than one keyword the redis call is failing because the keywords parameter is an array within the calling array. By concating the array to the end of the calling array this fixes the bug.
