### PR TITLE
Use sets for the object keys

### DIFF
--- a/lib/reds.js
+++ b/lib/reds.js
@@ -1,4 +1,3 @@
-
 /*!
  * reds
  * Copyright(c) 2011 TJ Holowaychuk <tj@vision-media.ca>
@@ -309,7 +308,7 @@ Search.prototype.index = function(str, id, fn){
   var cmds = [];
   keys.forEach(function(word, i){
     cmds.push(['zadd', key + ':word:' + map[word], counts[word], id]);
-    cmds.push(['zadd', key + ':object:' + id, counts[word], map[word]]);
+    cmds.push(['sadd', key + ':object:' + id, map[word]]);
   });
   db.multi(cmds).exec(fn || noop);
 
@@ -328,7 +327,7 @@ Search.prototype.remove = function(id, fn){
   var key = this.key;
   var db = this.client;
   
-  db.zrevrangebyscore(key + ':object:' + id, '+inf', 0, function(err, constants){
+  db.smembers(key + ':object:' + id, function(err, constants){
     if (err) return fn(err);
     var multi = db.multi().del(key + ':object:' + id);
     constants.forEach(function(c){


### PR DESCRIPTION
There's no need to store the object keys in sorted sets since they only exist to provide the remove functionality. Plain sets should be faster.

Note: this is kind of food for thought. I'm not sure what the right way to make this change would be since this would horribly break existing indexes.
