### PR TITLE
Handle errors on end before parsing ids.

### DIFF
--- a/lib/reds.js
+++ b/lib/reds.js
@@ -270,6 +270,9 @@ Query.prototype.end = function(fn){
     ['zrevrange', tkey, start, stop],
     ['zremrangebyrank', tkey, start, stop],
   ]).exec(function(err, ids) {
+    if (err) {
+      return fn(err)
+    }
     ids = ids[1];
     fn(err, ids);
   });


### PR DESCRIPTION
Currently reds throws an uncaught error trying to grab ids[1] since ids can be null when there is an error returned from the redis client.

If the redis client returns an error to the callback, `ids` can be null. 

```
// if ids = null then the following throws an error
ids = ids[1]
```