### PR TITLE
Feature: performance improvements

### DIFF
--- a/lib/reds.js
+++ b/lib/reds.js
@@ -10,8 +10,8 @@
  */
 
 var natural = require('natural');
-var metaphone = natural.Metaphone.process;
-var stem = natural.PorterStemmer.stem;
+var metaphone = require('metaphone');
+var stem = require('stemmer');
 var stopwords = natural.stopwords;
 var redis = require('redis');
 function noop(){};

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "dependencies": {
+    "metaphone": "^0.1.0",
     "natural": "0.1.17",
-    "redis": "0.7.2"
+    "redis": "0.7.2",
+    "stemmer": "^0.1.0"
   },
   "devDependencies": {
     "should": "^2.1.1",


### PR DESCRIPTION
By adding [stemmer](https://github.com/wooorm/stemmer) and [metaphone](https://github.com/wooorm/metaphone), performance on the benchmark increases significantly.

The benchmarks were done on a MacBook Air (late 2011), while listening to music and such, but the difference is certainly there.

Results w/ `stemmer` and `metaphone`:

```
             139 op/s » tiny
              29 op/s » small
              10 op/s » medium
               0 op/s » large
```

Results w/ `natural.Metaphone.process` and `natural.PorterStemmer.stem`:

```
              96 op/s » tiny
              20 op/s » small
               5 op/s » medium
               0 op/s » large
```

P.S. As my result are, both with and without this feature, slower than the benchmark in `Readme.md`, I’ve not updated it.
