### PR TITLE
Index prefixes of tokens

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ Search results for "tobi dollars":
 ## API
 
 ```js
-reds.createSearch(key)
+reds.createSearch(key[, options])
 Search#index(text, id[, fn])
 Search#remove(id[, fn]);
 Search#query(text, fn[, type]);
@@ -92,6 +92,13 @@ search.index('Foo bar', 'bcd');
 search.remove('bcd');
 search.query('foo bar').end(function(err, ids){});
 ```
+
+The `options` argument of `createSearch` enables customization of the search and indexing behavior:
+
+Option               | Default | Description
+-------------------- | ------- | -----------
+`prefix`             | `false` | Enables matching of word prefixes, e.g. querying "LearnBoos" would also match "LearnBoost"
+`weightExactMatches` | `10`    | Weight factor for exact matches relative to prefix matches, so matches for entire words are ranked higher than prefix matches
 
 ## About
 

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -66,9 +66,9 @@ exports.createClient = function(){
  * @api public
  */
 
-exports.createSearch = function(key){
+exports.createSearch = function(key, options){
   if (!key) throw new Error('createSearch() requires a redis key for namespacing');
-  return new Search(key);
+  return new Search(key, options);
 };
 
 /**
@@ -280,6 +280,11 @@ Query.prototype.end = function(fn){
   return this;
 };
 
+var defaults = {
+  prefix: false,
+  weightExactMatch: 10
+};
+
 /**
  * Initialize a new `Search` with the given `key`.
  *
@@ -287,9 +292,18 @@ Query.prototype.end = function(fn){
  * @api public
  */
 
-function Search(key) {
+function Search(key, options) {
   this.key = key;
   this.client = exports.createClient();
+  this.options = {};
+  for (var key in defaults) {
+    this.options[key] = defaults[key];
+  }
+  for (var key in options) {
+    if (options.hasOwnProperty(key)) {
+      this.options[key] = options[key];
+    }
+  }
 }
 
 /**
@@ -308,14 +322,18 @@ Search.prototype.index = function(str, id, fn){
   var counts = exports.countWords(words);
   var map = exports.metaphoneMap(words);
   var keys = Object.keys(map);
+  var prefix = this.options.prefix;
+  var weight = prefix ? this.options.weightExactMatch : 1;
 
   var cmds = [];
   keys.forEach(function(word){
-    for (var i = 1; i < map[word].length; ++i) {
-      var w = map[word].substr(0, i);
-      cmds.push(['zadd', key + ':word:' + w, counts[word], id]);
+    if (prefix) {
+      for (var i = 1; i < map[word].length; ++i) {
+        var w = map[word].substr(0, i);
+        cmds.push(['zadd', key + ':word:' + w, counts[word], id]);
+      }
     }
-    cmds.push(['zadd', key + ':word:' + map[word], 10 * counts[word], id]);
+    cmds.push(['zadd', key + ':word:' + map[word], weight * counts[word], id]);
     cmds.push(['zadd', key + ':object:' + id, counts[word], map[word]]);
   });
   db.multi(cmds).exec(fn || noop);
@@ -334,15 +352,19 @@ Search.prototype.remove = function(id, fn){
   fn = fn || noop;
   var key = this.key;
   var db = this.client;
+  var prefix = this.options.prefix;
   
   db.zrevrangebyscore(key + ':object:' + id, '+inf', 0, function(err, constants){
     if (err) return fn(err);
     var multi = db.multi().del(key + ':object:' + id);
     constants.forEach(function(c){
-      for (var i = 1; i <= c.length; ++i) {
-        var w = c.substr(0, i);
-        multi.zrem(key + ':word:' + w, id);
+      if (prefix) {
+        for (var i = 1; i < c.length; ++i) {
+          var w = c.substr(0, i);
+          multi.zrem(key + ':word:' + w, id);
+        }
       }
+      multi.zrem(key + ':word:' + c, id);
     });
     multi.exec(fn);
   });

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -310,8 +310,11 @@ Search.prototype.index = function(str, id, fn){
   var keys = Object.keys(map);
 
   var cmds = [];
-  keys.forEach(function(word, i){
-    cmds.push(['zadd', key + ':word:' + map[word], counts[word], id]);
+  keys.forEach(function(word){
+    for (var i = 1; i <= map[word].length; ++i) {
+      var w = map[word].substr(0, i);
+      cmds.push(['zadd', key + ':word:' + w, counts[word], id]);
+    }
     cmds.push(['zadd', key + ':object:' + id, counts[word], map[word]]);
   });
   db.multi(cmds).exec(fn || noop);
@@ -335,7 +338,10 @@ Search.prototype.remove = function(id, fn){
     if (err) return fn(err);
     var multi = db.multi().del(key + ':object:' + id);
     constants.forEach(function(c){
-      multi.zrem(key + ':word:' + c, id);
+      for (var i = 1; i <= c.length; ++i) {
+        var w = c.substr(0, i);
+        multi.zrem(key + ':word:' + w, id);
+      }
     });
     multi.exec(fn);
   });

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -311,10 +311,11 @@ Search.prototype.index = function(str, id, fn){
 
   var cmds = [];
   keys.forEach(function(word){
-    for (var i = 1; i <= map[word].length; ++i) {
+    for (var i = 1; i < map[word].length; ++i) {
       var w = map[word].substr(0, i);
       cmds.push(['zadd', key + ':word:' + w, counts[word], id]);
     }
+    cmds.push(['zadd', key + ':word:' + map[word], 10 * counts[word], id]);
     cmds.push(['zadd', key + ':object:' + id, counts[word], map[word]]);
   });
   db.multi(cmds).exec(fn || noop);

--- a/test/index.js
+++ b/test/index.js
@@ -228,13 +228,23 @@ function test() {
   ++pending;
   search.query('learnboos').end(function(err, ids){
     if (err) throw err;
-    ids.should.eql(['5']);
-    search.remove(5, function(err){
+    ids.should.eql([]);
+    --pending || done();
+  });
+
+  ++pending;
+  search = reds.createSearch('reds', {prefix: true});
+  search.index('Tobi is employed by LearnBoost', 15, function() {
+    search.query('learnboos').end(function(err, ids){
       if (err) throw err;
-      search.query('learnboos').end(function(err, ids){
+      ids.should.eql(['15']);
+      search.remove(15, function(err){
         if (err) throw err;
-        ids.should.eql([]);
-        --pending || done();
+        search.query('learnboos').end(function(err, ids){
+          if (err) throw err;
+          ids.should.eql([]);
+          --pending || done();
+        });
       });
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -224,6 +224,20 @@ function test() {
         });
       });
     });
+
+  ++pending;
+  search.query('learnboos').end(function(err, ids){
+    if (err) throw err;
+    ids.should.eql(['5']);
+    search.remove(5, function(err){
+      if (err) throw err;
+      search.query('learnboos').end(function(err, ids){
+        if (err) throw err;
+        ids.should.eql([]);
+        --pending || done();
+      });
+    });
+  });
 }
 
 function done() {


### PR DESCRIPTION
The current version of reds uses metaphonics and stemming but does not index prefixes, so when indexing "LearnBoost", you can find the id when querying "Lirnbast" but you cannot find it when searching for "LearnBoos".

This patch also indexes prefixes but I guess you probably want an option that turns this feature on or off.  This does not affect the performance of queries but makes indexing and removing somewhat slower.
