### PR TITLE
the query method should accepts optional callback and type parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,8 +35,7 @@ strs.forEach(function(str, i){ search.index(str, i); });
 
 ```js
 search
-  .query(query = 'Tobi dollars')
-  .end(function(err, ids){
+  .query(query = 'Tobi dollars', function(err, ids){
     if (err) throw err;
     console.log('Search results for "%s":', query);
     ids.forEach(function(id){

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,11 @@ Search results for "tobi dollars":
 reds.createSearch(key)
 Search#index(text, id[, fn])
 Search#remove(id[, fn]);
-Search#query(text, fn[, type]);
+Search#query(text[, type][, fn]); // will return a `Query` instance
+
+Query#between(start, stop)
+Query#type(type)
+Query#end(fn)
 ```
 
  Examples:

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -311,6 +311,7 @@ function Query(str, search, type) {
  */
 
 Query.prototype.type = function(type){
+  if (!type || !types[type]) return this;
   this._type = types[type];
   return this;
 };
@@ -431,8 +432,8 @@ Search.prototype.remove = function(id, fn){
 
 Search.prototype.query = function(query, type, fn){
   if (type && typeof type === 'function') {
-    fn = type
-    type = null
+    fn = type;
+    type = null;
     return new Query(query, this, type).end(fn);
   } else if (fn && typeof fn === 'function') {
     return new Query(query, this, type).end(fn);

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -45,7 +45,7 @@ var types = {
 };
 
 /**
- * Alternate way to set client 
+ * Alternate way to set client
  * provide your own behaviour.
  *
  * @param {RedisClient} inClient
@@ -72,7 +72,7 @@ exports.createClient = function(){
 
 /**
  * Process indexing string into NLP components (words, counts, map, keys)
- * 
+ *
  * @param {String} str
  * @param {String} [key]
  */
@@ -84,7 +84,7 @@ exports.nlpProcess = function(str, key) {
   //the key argument is only needed for removing items from the index
   //by not executing the `metaphoneKeys` function, it speeds up indexing a bit
   var metaphoneKeys = !key ? null : exports.metaphoneKeys(key, words)
-  
+
 
   return {
     words   : words,
@@ -98,13 +98,13 @@ exports.nlpProcess = function(str, key) {
 
 /**
  * Writes index to Redis
- * 
+ *
  * @param {Object} db Redis Client
  * @param {Number|String} id
  * @param {String} key
  * @param {Object} nlpObj Object with word map, counts, and keys
  * @param {Function} fn
- * 
+ *
  */
 exports.writeIndex = function(db, id, key, nlpObj, fn) {
   var cmds = [];
@@ -117,12 +117,12 @@ exports.writeIndex = function(db, id, key, nlpObj, fn) {
 
 /**
  * Removes index from Redis
- * 
+ *
  * @param {Object} db Redis Client
  * @param {Number|String} id
  * @param {String} key
  * @param {Function} fn
- * 
+ *
  */
 exports.removeIndex = function(db, id, key, fn) {
   db.zrevrangebyscore(key + ':object:' + id, '+inf', 0, function(err, constants){
@@ -146,12 +146,12 @@ exports.removeIndex = function(db, id, key, fn) {
 
 exports.createSearch = function(key,opts){
   if (!key) throw new Error('createSearch() requires a redis key for namespacing');
-  
+
   opts = !opts ? {} : opts;
   opts.nlpProcess = !opts.nlpProcess ? exports.nlpProcess : opts.nlpProcess;
   opts.writeIndex = !opts.writeIndex ? exports.writeIndex : opts.writeIndex;
   opts.removeIndex = !opts.removeIndex ? exports.removeIndex : opts.removeIndex;
-  
+
   return new Search(key, opts.nlpProcess, opts.writeIndex, opts.removeIndex);
 };
 
@@ -260,12 +260,12 @@ exports.metaphoneArray = function(words){
   var constant;
 
   if (!words) return arr;
-  
+
   for (var i = 0, len = words.length; i < len; ++i) {
     constant = metaphone(words[i]);
     if (!~arr.indexOf(constant)) arr.push(constant);
   }
-  
+
   return arr;
 };
 
@@ -286,17 +286,18 @@ exports.metaphoneKeys = function(key, words){
 };
 
 /**
- * Initialize a new `Query` with the given `str`
- * and `search` instance.
+ * Initialize a new `Query` with the given `str`,
+ * `search` instance and a optional `type` string.
  *
  * @param {String} str
  * @param {Search} search
+ * @param {String} type
  * @api public
  */
 
-function Query(str, search) {
+function Query(str, search, type) {
   this.str = str;
-  this.type('and');
+  this.type(type && types[type] ? type : 'and');
   this.search = search;
 }
 
@@ -403,6 +404,7 @@ Search.prototype.index = function(str, id, fn){
  * Remove occurrences of `id` from the index.
  *
  * @param {Number|String} id
+ * @param {Function} fn
  * @api public
  */
 
@@ -410,9 +412,9 @@ Search.prototype.remove = function(id, fn){
   fn = fn || noop;
   var key = this.key;
   var db = this.client;
-  
+
   this.removeIndex(db, id, key, fn);
-  
+
   return this;
 };
 
@@ -421,10 +423,18 @@ Search.prototype.remove = function(id, fn){
  * a `Query` instance.
  *
  * @param {String} query
- * @param {Query}
+ * @param {Function} fn
+ * @param {String} type
+ * @return {Query} for chaining
  * @api public
  */
 
-Search.prototype.query = function(query){
+Search.prototype.query = function(query, fn, type){
+  if (fn && typeof fn === 'function') {
+    return new Query(query, this, type).end(fn);
+  } else if (fn) {
+    type = fn
+    return new Query(query, this, type);
+  }
   return new Query(query, this);
 };

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -429,12 +429,13 @@ Search.prototype.remove = function(id, fn){
  * @api public
  */
 
-Search.prototype.query = function(query, fn, type){
-  if (fn && typeof fn === 'function') {
+Search.prototype.query = function(query, type, fn){
+  if (type && typeof type === 'function') {
+    fn = type
+    type = null
     return new Query(query, this, type).end(fn);
-  } else if (fn) {
-    type = fn
-    return new Query(query, this, type);
+  } else if (fn && typeof fn === 'function') {
+    return new Query(query, this, type).end(fn);
   }
-  return new Query(query, this);
+  return new Query(query, this, type);
 };

--- a/lib/reds.js
+++ b/lib/reds.js
@@ -297,7 +297,7 @@ exports.metaphoneKeys = function(key, words){
 
 function Query(str, search, type) {
   this.str = str;
-  this.type(type && types[type] ? type : 'and');
+  this.type(type || 'and');
   this.search = search;
 }
 
@@ -311,8 +311,7 @@ function Query(str, search, type) {
  */
 
 Query.prototype.type = function(type){
-  if (!type || !types[type]) return this;
-  this._type = types[type];
+  this._type = type && types[type] ? types[type] : types['and'];
   return this;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -172,7 +172,7 @@ function nonModularTests(finish) {
 
     ++pending;
     search
-      .query('dog ideas', function(err, ids){
+      .query('dog ideas', 'or', function(err, ids){
         if (err) { throw err; }
         ids.should.have.length(3);
         ids.should.include('7');
@@ -180,7 +180,7 @@ function nonModularTests(finish) {
         ids.should.include('9');
         ids[0].should.eql('9');
         --pending || done();
-      }, 'or');
+      });
 
     ++pending;
     //refactor this with async soon

--- a/test/index.js
+++ b/test/index.js
@@ -119,6 +119,25 @@ function nonModularTests(finish) {
     ++pending;
     search
       .query('loki and jane')
+      .type('invalid type')
+      .end(function(err, ids){
+        if (err) { throw err; }
+        ids.should.eql([]);
+        --pending || done();
+      });
+
+    ++pending;
+    search
+      .query('loki and jane', 'invalid type')
+      .end(function(err, ids){
+        if (err) { throw err; }
+        ids.should.eql([]);
+        --pending || done();
+      });
+
+    ++pending;
+    search
+      .query('loki and jane')
       .end(function(err, ids){
         if (err) { throw err; }
         ids.should.eql([]);

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ function nonModularTests(finish) {
     db.quit();
     finish();
   };
-  
+
   test = function() {
     var pending = 0;
 
@@ -38,6 +38,14 @@ function nonModularTests(finish) {
     search
       .query('stuff compute')
       .end(function(err, ids){
+        if (err) { throw err; }
+        ids.should.eql(['6']);
+        --pending || done();
+      });
+
+    ++pending;
+    search
+      .query('stuff compute', function(err, ids){
         if (err) { throw err; }
         ids.should.eql(['6']);
         --pending || done();
@@ -99,8 +107,7 @@ function nonModularTests(finish) {
 
     ++pending;
     search
-      .query('loki and jane')
-      .type('or')
+      .query('loki and jane', 'or')
       .end(function(err, ids){
         if (err) { throw err; }
         ids.should.have.length(2);
@@ -164,6 +171,18 @@ function nonModularTests(finish) {
       });
 
     ++pending;
+    search
+      .query('dog ideas', function(err, ids){
+        if (err) { throw err; }
+        ids.should.have.length(3);
+        ids.should.include('7');
+        ids.should.include('8');
+        ids.should.include('9');
+        ids[0].should.eql('9');
+        --pending || done();
+      }, 'or');
+
+    ++pending;
     //refactor this with async soon
     search
       .index('keyboard cat', 6, function(err){
@@ -193,7 +212,7 @@ function nonModularTests(finish) {
 
 
   search = reds.createSearch('reds');
-  
+
   reds
     .words('foo bar baz ')
     .should.eql(['foo', 'bar', 'baz']);
@@ -263,7 +282,7 @@ function modularTest(next) {
       });
     },
     nonPhoneticMap      = function(words){
-      var 
+      var
         obj = {},
         len,
         i;
@@ -294,8 +313,8 @@ function modularTest(next) {
       };
     };
 
-  
-  
+
+
   console.log('Starting modular test');
   reds.client.quit();
 
@@ -320,9 +339,9 @@ function modularTest(next) {
   });
 
   search.index(testString,'x');
-  
+
   should.exist(search[writeIndexTestProp])
-  
+
   //with the normal nlpProcessor, 'trent' and 'toronto' will turn into the same metaphones, test ot make sure that isn't happening.
   search[writeIndexTestProp]
     .should
@@ -347,7 +366,7 @@ function modularTest(next) {
       search
         .query('trent')
         .end(function(err,results) {
-          if (err) { throw err; } 
+          if (err) { throw err; }
           results.should.eql(['x']); //if it was using the standard nlpParser then it would be ['x','y']
           console.log('  completed in %dms', new Date() - start);
 


### PR DESCRIPTION
As mentioned in [Readme.md](https://github.com/tj/reds/blob/master/Readme.md#api):

- `Search#query(text, fn[, type]);`

`Search#query` should accepts both optional callback and type parameters.

After added these optional parameters in `Search#query`, we can perform a query against reds simply invoke `Search#query()` with a string, and pass a callback directly. 